### PR TITLE
Minor error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ class Controller {
   }
 
   update(currentValue) {
+    if(!currentValue) throw new Error("Invalid argument");
     this.currentValue = currentValue;
 
     // Calculate dt

--- a/test/index.js
+++ b/test/index.js
@@ -82,4 +82,12 @@ describe('pid-controller', () => {
     correction.should.equal(0);
   });
 
+  it('should throw error when updating a NaN value', () => {
+    let ctr = new Controller(0,0,0);
+    ctr.setTarget(20);
+    should.throws(() => {
+      ctr.update(NaN);
+    }, Error, "Invalid argument")
+  });
+
 });


### PR DESCRIPTION
If the update method is called with an undefined value, everything will break because every arithmetic operation will to NaN and sumError cascaded to NaN. 

It would be better if an invalid value is ignored in the update process.